### PR TITLE
Remove encoder debounce 'fix' and fix interrupt triggers

### DIFF
--- a/src/control/encoders.h
+++ b/src/control/encoders.h
@@ -24,36 +24,17 @@ static uint32_t last_R_tick = 0;
 static uint32_t curr_L_tick = 0;
 static uint32_t curr_R_tick = 0;
 
-// This variable is probably important for the debouncing of the encoder ticks, might get crazy values otherwise
-// We have measured down to CA 1ms, but this introduces noise
-// 100 comes from trial and error
-static uint32_t debouce_Time = 100;
-
 void R_TICK() {
-    noInterrupts();
-    unsigned long R_interrupt_time = micros();
-    if (R_interrupt_time - last_R_interrupt_time > debouce_Time) {
-        curr_R_tick++;
-        last_R_interrupt_time = R_interrupt_time;
-        // Serial.println("Encoder_msg.right_time_delta: " + String(encoder_msg.right_time_delta / 1e3) + "us");
-        // Serial.println("R ticks: " + String(encoder_msg.right_ticks));
-    }
-    interrupts();
+    curr_R_tick++;
 }
 
 void L_TICK() {
-    noInterrupts();
-    unsigned long L_interrupt_time = micros();
-    if (L_interrupt_time - last_L_interrupt_time > debouce_Time) {
-        curr_L_tick++;
-        last_L_interrupt_time = L_interrupt_time;
-    }
-    interrupts();
+    curr_L_tick++;
 }
 
 svea_msgs::lli_encoder process_encoder(){
-    noInterrupts();
     svea_msgs::lli_encoder encoder_msg;
+    noInterrupts();
     encoder_msg.right_ticks = curr_R_tick - last_R_tick;
     encoder_msg.left_ticks = curr_L_tick - last_L_tick;
     uint32_t current_time = micros();
@@ -77,8 +58,8 @@ void setupEncoders() {
     pinMode(ENCODER_R_2, INPUT_PULLUP);
 
     // Settings for pin change interrupts for detecting wheel encoder ticks
-    attachInterrupt(ENCODER_L_2, L_TICK, RISING);
-    attachInterrupt(ENCODER_R_2, R_TICK, RISING);
+    attachInterrupt(digitalPinToInterrupt(ENCODER_L_2), L_TICK, CHANGE);
+    attachInterrupt(digitalPinToInterrupt(ENCODER_R_2), R_TICK, CHANGE);
 }
 
 } // namespace Encoders

--- a/src/control/encoders.h
+++ b/src/control/encoders.h
@@ -9,41 +9,30 @@ svea_msgs::lli_encoder encoder_msg;
 #define ENCODER_R_1 22
 #define ENCODER_R_2 23
 
-static uint32_t last_L_interrupt_time = 0;
-static uint32_t last_R_interrupt_time = 0;
+static uint32_t last_publish_time = 0;
 
-static uint32_t curr_L_interrupt_time = 0;
-static uint32_t curr_R_interrupt_time = 0;
-
-static uint32_t last_L_publish_time = 0;
-static uint32_t last_R_publish_time = 0;
-
-static uint32_t last_L_tick = 0;
-static uint32_t last_R_tick = 0;
-
-static uint32_t curr_L_tick = 0;
-static uint32_t curr_R_tick = 0;
-
-void R_TICK() {
-    curr_R_tick++;
-}
+static uint32_t L_ticks = 0;
+static uint32_t R_ticks = 0;
 
 void L_TICK() {
-    curr_L_tick++;
+    L_ticks++;
+}
+
+void R_TICK() {
+    R_ticks++;
 }
 
 svea_msgs::lli_encoder process_encoder(){
     svea_msgs::lli_encoder encoder_msg;
     noInterrupts();
-    encoder_msg.right_ticks = curr_R_tick - last_R_tick;
-    encoder_msg.left_ticks = curr_L_tick - last_L_tick;
+    encoder_msg.left_ticks = L_ticks;
+    encoder_msg.right_ticks = R_ticks;
+    L_ticks = 0;
+    R_ticks = 0;
     uint32_t current_time = micros();
-    encoder_msg.right_time_delta = current_time - last_R_publish_time;
-    encoder_msg.left_time_delta = current_time - last_L_publish_time;
-    last_R_publish_time = current_time;
-    last_L_publish_time = current_time;
-    last_R_tick = curr_R_tick;
-    last_L_tick = curr_L_tick;
+    encoder_msg.right_time_delta = current_time - last_publish_time;
+    encoder_msg.left_time_delta = current_time - last_publish_time;
+    last_publish_time = current_time;
     interrupts();
     return encoder_msg;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,6 +118,7 @@ static bool servo_idle = false;
 int l = 0;
 //! Main loop
 void loop() {
+    unsigned long start = millis();
     int sw_status = nh.spinOnce();
     unsigned long d_since_last_msg = millis() - SW_T_RECIEVED;
     checkEmergencyBrake();
@@ -141,5 +142,6 @@ void loop() {
     encoder_pub.publish(&Encoders::process_encoder());
     // Serial.printf("RDelta%d\n", &Encoders::encoder_msg.right_time_delta);
     imu_sensor.update();
-    delay(50); //delay for 50 ms
+    unsigned long loop_time = millis() - start;
+    delay(max(0, 10 - loop_time)); //100 Hz loop
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,7 @@ static bool servo_idle = false;
 int l = 0;
 //! Main loop
 void loop() {
-    unsigned long start = millis();
+    unsigned long start = micros();
     int sw_status = nh.spinOnce();
     unsigned long d_since_last_msg = millis() - SW_T_RECIEVED;
     checkEmergencyBrake();
@@ -142,6 +142,6 @@ void loop() {
     encoder_pub.publish(&Encoders::process_encoder());
     // Serial.printf("RDelta%d\n", &Encoders::encoder_msg.right_time_delta);
     imu_sensor.update();
-    unsigned long loop_time = millis() - start;
-    delay(max(0, 10 - loop_time)); //100 Hz loop
+    unsigned long loop_time = micros() - start; // do not use millis() instead of micros() to prevent hang-ups
+    delay(max(0, 10 - loop_time/1000)); //100 Hz loop. Do not use delayMicroseconds(...) instead of delay(...) to prevent hang-ups
 }


### PR DESCRIPTION
- Remove the debounce time in code that is unnecessary after physically shorting U8 and U12 on the powerboard.
- Change interrupt triggers from rising edge to rising+falling edge.
- Properly limit the main LLI loop to 100Hz.